### PR TITLE
Replaces the user guide's button text with a question icon

### DIFF
--- a/app/assets/stylesheets/spree/backend/user_guides.css
+++ b/app/assets/stylesheets/spree/backend/user_guides.css
@@ -9,9 +9,31 @@
   bottom:10px;
   right:10px;
   z-index:99999;
-  padding: 5px 10px;
-  font-size: initial;
+  padding:5px 10px;
+  font-size:initial;
+  border-radius:100%;
+  background:white;
+  display:flex;
+  justify-content:center;
+  align-items: center;
+  height: 30px;
+  width: 30px;
 }
+
+#panel-button:hover,
+#panel-button:focus:hover {
+  box-shadow: 0 0 0 0.2rem rgba(61, 118, 241, 0.5);
+}
+
+#panel-button:focus {
+  box-shadow: none;
+}
+
+#panel-button .user-guide-icon{
+  color: #3D76F1;
+  font-size: 2.2em;
+}
+
 #panelModal .modal-title{
   font-size:17px;
   margin:0px;

--- a/app/views/solidus_user_guides/_user_guides.html.erb
+++ b/app/views/solidus_user_guides/_user_guides.html.erb
@@ -1,8 +1,8 @@
 <% guide_text = Rails.configuration.user_guides.dig controller_name, action_name %>
 
 <% if guide_text %>
-  <button type="button" class="btn btn-primary" id="panel-button" data-toggle="modal" data-target="#panelModal">
-    User Guide
+  <button type="button" class="btn btn-primary" id="panel-button" data-toggle="modal" data-target="#panelModal" title="User Guide">
+    <i class="fa fa-question-circle user-guide-icon"></i>
   </button>
 
   <div class="modal fade" id="panelModal" tabindex="-1" role="dialog" aria-labelledby="panelModalLabel" aria-hidden="true">


### PR DESCRIPTION
Also, a "User Guide" tooltip pops up when hovering the (?) button.

|Before|After|
|--|--|
|![1](https://user-images.githubusercontent.com/3853105/112674244-f8af2100-8e65-11eb-83e6-7deb2da033a6.png)|![2](https://user-images.githubusercontent.com/3853105/112674255-fa78e480-8e65-11eb-8354-6163f188d80b.png)|
